### PR TITLE
lightdm.service only exists in the desktop target

### DIFF
--- a/overlay/etc/init.d/rockchip.sh
+++ b/overlay/etc/init.d/rockchip.sh
@@ -52,7 +52,8 @@ then
     setcap CAP_SYS_ADMIN+ep /usr/bin/gst-launch-1.0
     rm -rf /packages
 
-    systemctl restart lightdm.service
+    # The base target does not come with lightdm
+    systemctl restart lightdm.service || true
 fi
 
 # read mac-address from efuse


### PR DESCRIPTION
This change will allow rockchip.sh to exit successfully when the rootfs is base / not desktop target.